### PR TITLE
feat(devops): Implementa Dockerfile multi-etapa para Frontend

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,21 @@
+# Dependencias locales
+node_modules/
+
+# Archivos de Git
+.git
+.gitignore
+
+# Archivos de build local
+dist/
+
+# Archivos de IDE y SO
+.idea/
+.vscode/
+*.iml
+.DS_Store
+
+# Entornos y logs
+.env
+.env.local
+.env.example
+npm-debug.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,37 @@
+# --- ETAPA 1: BUILD (Compilación de Vue/Vite) ---
+# Usar node:22-alpine
+FROM node:22-alpine AS builder
+
+# Define el argumento de build para la URL de la API
+# Esto nos permitirá pasar el VITE_API_URL desde la GitHub Action
+ARG VITE_API_URL
+
+WORKDIR /app
+
+# Copia los package.json y package-lock.json
+COPY package.json package-lock.json* ./
+
+# Instala dependencias
+RUN npm install
+
+# Copia el resto del código fuente
+COPY . .
+
+# Construye la aplicación (Build)
+# Inyecta el ARG como una variable de entorno ANTES de construir
+RUN VITE_API_URL=${VITE_API_URL} npm run build
+
+# --- ETAPA 2: SERVE (Servidor Nginx) ---
+FROM nginx:stable-alpine
+
+# Copia la configuración personalizada de Nginx para createWebHistory
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+
+# Copia los archivos estáticos construidos
+COPY --from=builder /app/dist /usr/share/nginx/html
+
+# Expone el puerto 80 (puerto estándar de Nginx)
+EXPOSE 80
+
+# Comando de inicio
+CMD ["nginx", "-g", "daemon off;"]

--- a/README.md
+++ b/README.md
@@ -42,3 +42,16 @@ npm run build
 ```sh
 npm run lint
 ```
+
+
+### Construir y ejecutar el front
+Para pruebas en local, construimos el front en el puerto 8082 y lo conectamos a la API del puerto 8080:
+
+```sh
+docker build --build-arg VITE_API_URL=http://localhost:8080 -t fitapp-frontend-local .
+```
+
+```sh
+docker run -p 8082:80 --rm fitapp-frontend-local    
+```
+

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,12 @@
+server {
+   listen 80;
+   root /usr/share/nginx/html;
+   index index.html;
+
+   # Esta es la regla mágica para Vue Router (modo history)
+   # Si no encuentra el archivo ($uri) o directorio ($uri/),
+   # devuelve /index.html para que Vue maneje la ruta.
+   location / {
+      try_files $uri $uri/ /index.html;
+   }
+}


### PR DESCRIPTION
### Descripción
Este PR introduce los archivos necesarios para contenerizar el Frontend (`fitapp-fe`). El objetivo es tener la imagen lista para ser construida y desplegada por el pipeline de CI/CD (Issue 5).

### Cambios Clave
* **`Dockerfile` (Nuevo):** Un `Dockerfile` multi-etapa que usa `node:22-alpine` para el build y `nginx:stable-alpine` para servir.
* **`nginx.conf` (Nuevo):** Configuración de Nginx para soportar `createWebHistory` (modo history) de Vue Router, evitando errores 404 al refrescar la página.
* **`.dockerignore` (Nuevo):** Archivo de exclusión para `node_modules`, `.env`, etc.
* **`ARG VITE_API_URL`:** El `Dockerfile` ahora acepta un `--build-arg VITE_API_URL` para inyectar la URL de la API de producción durante el build de GitHub Actions.

### 🧪 Validación Local (Criterio Final)
Se ha validado localmente con éxito ejecutando:

```bash
# 1. Construcción (inyectando la API local para la prueba)
docker build --build-arg VITE_API_URL=http://localhost:8080 -t fitapp-frontend-local .
# 2. Ejecución (en el puerto 8082)
docker run -p 8082:80 --rm fitapp-frontend-local
```
La aplicación carga en http://localhost:8082 y Nginx sirve las rutas correctamente.

Closes #28 